### PR TITLE
Clear desired_locations & getProjectCards desc

### DIFF
--- a/routes/projects/projects.js
+++ b/routes/projects/projects.js
@@ -113,6 +113,8 @@ function getProjectCards() {
           db.raw("array_agg(distinct pm.media) as project_media")
         )
         .leftOuterJoin("project_media as pm", "pm.project_id", "p.id")
+        .limit(8)
+        .orderBy("p.id", "desc")
         .groupBy("p.id");
 
       resolve(projects);

--- a/routes/students/students.js
+++ b/routes/students/students.js
@@ -58,7 +58,6 @@ function getStudentById(id) {
             db.raw("array_agg(distinct sk.skill) as skills"),
             db.raw("array_agg(distinct h.hobby) as hobbies"),
             db.raw("array_agg(distinct ts.skill) as top_skills")
-            //db.raw("array_agg(distinct dl.location) as desired_locations")
           )
           .leftOuterJoin("accounts as a", "a.id", "s.account_id")
           .leftOuterJoin("cohorts as c", "c.id", "s.cohort_id")
@@ -66,7 +65,6 @@ function getStudentById(id) {
           .leftOuterJoin("student_skills as sk", "sk.student_id", "s.id")
           .leftOuterJoin("hobbies as h", "h.student_id", "s.id")
           .leftOuterJoin("top_skills as ts", "ts.student_id", "s.id")
-          // .leftOuterJoin("desired_locations as dl", "dl.student_id", "s.id")
           .groupBy("a.name", "s.id", "c.cohort_name", "t.name")
           .where({ "s.id": id })
           .first()
@@ -246,7 +244,6 @@ function getStudentProfile(account_id, update) {
             db.raw("array_agg(distinct sk.skill) as skills"),
             db.raw("array_agg(distinct h.hobby) as hobbies"),
             db.raw("array_agg(distinct ts.skill) as top_skills")
-            //db.raw("array_agg(distinct dl.location) as desired_locations")
           )
           .leftOuterJoin("accounts as a", "a.id", "s.account_id")
           .leftOuterJoin("cohorts as c", "c.id", "s.cohort_id")
@@ -254,7 +251,6 @@ function getStudentProfile(account_id, update) {
           .leftOuterJoin("student_skills as sk", "sk.student_id", "s.id")
           .leftOuterJoin("hobbies as h", "h.student_id", "s.id")
           .leftOuterJoin("top_skills as ts", "ts.student_id", "s.id")
-          // .leftOuterJoin("desired_locations as dl", "dl.student_id", "s.id")
           .groupBy("a.name", "s.id", "c.cohort_name", "t.name")
           .where({ "s.account_id": account_id })
           .first()
@@ -491,9 +487,13 @@ function updateStudent(account_id, info) {
             .where({ student_id: student.id })
             .del()
             .transacting(t);
-          desired_locations = await db("desired_locations")
-            .insert(info.desired_locations, "*")
-            .transacting(t);
+          if (info.desired_locations[0].location) {
+            desired_locations = await db("desired_locations")
+              .insert(info.desired_locations, "*")
+              .transacting(t);
+          } else {
+            desired_locations = [];
+          }
         }
 
         let top_projects;


### PR DESCRIPTION
# Description
- Adds logic to clear desired_locations
- Adds a limit of 8 records to the `getProjectCards()` and sorts them in descending order, so that the most recent projects are showcased on home page

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts